### PR TITLE
Add patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/graphql-norm-stale/compare/v0.4.0...master)
 
+### Added
+
+- Add patches for invlidation/staleness from the graphql-norm-patch package. See PR [#2](https://github.com/dividab/graphql-norm-stale/pull/2) for more info.
+
 ## [0.4.0](https://github.com/dividab/graphql-norm-stale/compare/v0.3.0...v0.4.0) - 2019-10-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ The `clearStale()` function takes a map of normalized GraphQL objects and a map 
 clearStale(normMap: NormMap, staleMap: FieldsMap): FieldsMap
 ```
 
+### invalidateEntity()
+
+Creates a patch for invalidation of an entity.
+
+### invalidateField()
+
+Creates a patch for invalidation of an entity's field.
+
+### applyPatches()
+
+Returns a new map of stale fields with the patches applied. It needs the `normMap` in order to do recursive patches.
+
+```ts
+applyPatches(normMap: NormMap, staleMap: FieldsMap): FieldsMap
+```
+
 ## Related packages
 
 - [graphql-norm](https://www.npmjs.com/package/graphql-norm)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
 export { clearStale, isStale } from "./stale";
+export {
+  Patch,
+  applyPatches,
+  invalidateEntity,
+  InvalidateEntity,
+  invalidateField,
+  InvalidateField
+} from "./patch";

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,0 +1,205 @@
+import {
+  NormMap,
+  FieldsMap,
+  NormFieldValue,
+  NormKey,
+  NormObj
+} from "graphql-norm";
+
+export type Patch = InvalidateEntity | InvalidateField;
+
+export interface InvalidateEntity {
+  readonly type: "InvalidateEntity";
+  readonly id: string;
+  readonly recursive: boolean;
+}
+
+export interface InvalidateField {
+  readonly type: "InvalidateField";
+  readonly id: string;
+  readonly fieldName: string;
+  readonly recursive: boolean;
+  readonly fieldArguments: {} | undefined;
+}
+
+/**
+ *  Makes an entity stale in the cache
+ */
+export function invalidateEntity(
+  id: NormKey,
+  recursive: boolean
+): InvalidateEntity {
+  return {
+    type: "InvalidateEntity",
+    id,
+    recursive
+  };
+}
+
+/**
+ *  Makes a field stale in the cache
+ */
+export function invalidateField<T = NormObj, A extends {} = {}>(
+  id: NormKey,
+  fieldName: Extract<keyof T, string>,
+  recursive: boolean,
+  fieldArguments?: A
+): InvalidateField {
+  return {
+    type: "InvalidateField",
+    id,
+    fieldName,
+    recursive,
+    fieldArguments
+  };
+}
+
+// eslint-disable-next-line functional/prefer-readonly-type
+type MutableFieldsMap = { [key: string]: Set<string> };
+
+export function applyPatches(
+  patches: ReadonlyArray<Patch>,
+  cache: NormMap,
+  staleMap: FieldsMap
+): FieldsMap {
+  if (patches.length === 0) {
+    return staleMap;
+  }
+  // Make a shallow copy of the stale entities
+  const staleEntitiesCopy: MutableFieldsMap = {
+    ...(staleMap as MutableFieldsMap)
+  };
+  for (const patch of patches) {
+    switch (patch.type) {
+      case "InvalidateEntity": {
+        applyInvalidateEntity(patch, cache, staleEntitiesCopy);
+        break;
+      }
+      case "InvalidateField": {
+        applyInvalidateField(patch, cache, staleEntitiesCopy);
+        break;
+      }
+      default: {
+        const exhaustiveCheck = (x: never): void => x;
+        exhaustiveCheck(patch);
+      }
+    }
+  }
+
+  return staleEntitiesCopy;
+}
+
+function applyInvalidateEntity(
+  patch: InvalidateEntity,
+  cache: NormMap,
+  staleEntities: MutableFieldsMap
+): void {
+  const entity = cache[patch.id];
+  if (entity !== undefined) {
+    const newStaleEntity: Set<string> = new Set(staleEntities[patch.id]);
+    for (const entityKey of Object.keys(entity)) {
+      newStaleEntity.add(entityKey);
+      if (patch.recursive) {
+        invalidateRecursive(cache, staleEntities, entity[entityKey]);
+      }
+    }
+    staleEntities[patch.id] = newStaleEntity;
+  }
+}
+
+function applyInvalidateField(
+  patch: InvalidateField,
+  cache: NormMap,
+  staleEntities: MutableFieldsMap
+): void {
+  if (cache[patch.id] !== undefined) {
+    // We want to invalidate all fields that start with the specified
+    // field name in order to invlidate fields with arguments
+    // For example the fields "products" and "products(ids: [1, 2])" should
+    // both be invalidated if the field name "products" is specified
+    const entityFieldKeys = Object.keys(cache[patch.id]).filter(
+      k => k.indexOf(withArgs(patch.fieldName, patch.fieldArguments)) !== -1
+    );
+
+    if (entityFieldKeys.length === 0) {
+      return;
+    }
+
+    for (const fieldKey of entityFieldKeys) {
+      const existingFields = staleEntities[patch.id] || [];
+      staleEntities[patch.id] = new Set([...existingFields, fieldKey]);
+      if (patch.recursive) {
+        // Shallow mutation of stale entities OK as we have a shallow copy
+        invalidateRecursive(cache, staleEntities, cache[patch.id][fieldKey]);
+      }
+    }
+  }
+}
+
+function invalidateRecursive(
+  cache: NormMap,
+  staleEntities: MutableFieldsMap,
+  startingEntity: NormFieldValue | null
+): void {
+  if (
+    typeof startingEntity === "number" ||
+    typeof startingEntity === "boolean" ||
+    startingEntity === "undefined" ||
+    startingEntity === "null"
+  ) {
+    return;
+  }
+
+  const stack: Array<string> = [];
+
+  if (typeof startingEntity === "string" && cache[startingEntity]) {
+    stack.push(startingEntity);
+  } else if (isArrayOfEntityIds(cache, startingEntity)) {
+    stack.push(...startingEntity);
+  }
+
+  while (stack.length > 0) {
+    const entityId = stack.shift()!;
+    const entity = cache[entityId];
+    if (entity === undefined) {
+      continue;
+    }
+    const entityFieldKeys = Object.keys(entity);
+    const newStaleEntity: Set<string> = new Set(staleEntities[entityId]);
+
+    for (const entityFieldKey of entityFieldKeys) {
+      const entityField = entity[entityFieldKey];
+      if (isArrayOfEntityIds(cache, entityField)) {
+        stack.push(...entityField.filter(id => !staleEntities[id]));
+      } else if (
+        typeof entityField === "string" &&
+        cache[entityField] &&
+        !staleEntities[entityField]
+      ) {
+        stack.push(entityField);
+      }
+      newStaleEntity.add(entityFieldKey);
+    }
+
+    staleEntities[entityId] = newStaleEntity;
+  }
+}
+
+function withArgs(fieldName: string, fieldArguments: {} | undefined): string {
+  if (fieldArguments === undefined) {
+    return fieldName;
+  }
+  const hashedArgs = JSON.stringify(fieldArguments);
+  return fieldName + "(" + hashedArgs + ")";
+}
+
+function isArrayOfEntityIds(
+  cache: NormMap,
+  field: NormFieldValue | null
+): field is ReadonlyArray<NormKey> {
+  if (Array.isArray(field) && field.some(x => !!cache[x])) {
+    return true;
+  }
+
+  return false;
+}

--- a/test/apply-patches-def.ts
+++ b/test/apply-patches-def.ts
@@ -1,0 +1,12 @@
+import { NormMap, FieldsMap } from "graphql-norm";
+import { Patch } from "../src";
+
+export interface OneTest {
+  readonly name: string;
+  readonly only?: true;
+  readonly patches: ReadonlyArray<Patch>;
+  readonly cacheBefore: NormMap;
+  readonly cacheAfter: NormMap;
+  readonly staleBefore?: FieldsMap;
+  readonly staleAfter?: FieldsMap;
+}

--- a/test/apply-patches-test-data.ts
+++ b/test/apply-patches-test-data.ts
@@ -1,0 +1,4 @@
+import { loadTests } from "./test-data-utils";
+import { OneTest } from "./apply-patches-def";
+
+export const tests = loadTests<OneTest>("apply-patches/");

--- a/test/apply-patches.test.ts
+++ b/test/apply-patches.test.ts
@@ -1,0 +1,17 @@
+import { tests } from "./apply-patches-test-data";
+import { onlySkip } from "./test-data-utils";
+import { applyPatches } from "../src";
+
+describe("applyPatches", () => {
+  onlySkip(tests).forEach(testCase => {
+    test(testCase.name, done => {
+      const actualStale = applyPatches(
+        testCase.patches,
+        testCase.cacheBefore,
+        testCase.staleBefore || {}
+      );
+      expect(actualStale).toEqual(testCase.staleAfter || {});
+      done();
+    });
+  });
+});

--- a/test/apply-patches/invalidate-entity.ts
+++ b/test/apply-patches/invalidate-entity.ts
@@ -1,0 +1,64 @@
+import { OneTest } from "../apply-patches-def";
+import { invalidateEntity } from "../../src";
+
+const testObj2 = { id: "obj2", names: ["foo", "bar"] };
+
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "invalidateEntity recursive=false with shallow data",
+    patches: [invalidateEntity("obj2", false)],
+    cacheBefore: { obj2: testObj2 },
+    cacheAfter: { obj2: testObj2 },
+    staleBefore: {},
+    staleAfter: { obj2: new Set(["id", "names"]) }
+  },
+  {
+    name: "invalidateEntity recursive=true with shallow data",
+    patches: [invalidateEntity("obj2", true)],
+    cacheBefore: { obj2: testObj2 },
+    cacheAfter: { obj2: testObj2 },
+    staleBefore: {},
+    staleAfter: { obj2: new Set(["id", "names"]) }
+  },
+  {
+    name: "invalidateEntity recursive=false with deep data",
+    patches: [invalidateEntity("myid", false)],
+    cacheBefore: {
+      myid: { id: "myid", prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    cacheAfter: {
+      myid: { id: "myid", prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    staleBefore: {},
+    staleAfter: { myid: new Set(["id", "prop"]) }
+  },
+  {
+    name: "invalidateEntity recursive=true with deep data",
+    patches: [invalidateEntity("myid", true)],
+    cacheBefore: {
+      myid: { id: "myid", prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    cacheAfter: {
+      myid: { id: "myid", prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    staleBefore: {},
+    staleAfter: {
+      myid: new Set(["id", "prop"]),
+      "obj:1": new Set(["id", "news"]),
+      "NewsItemType:1": new Set(["id", "header"]),
+      "NewsItemType:2": new Set(["id", "header"])
+    }
+  }
+];

--- a/test/apply-patches/invalidate-field.ts
+++ b/test/apply-patches/invalidate-field.ts
@@ -1,0 +1,123 @@
+import { OneTest } from "../apply-patches-def";
+import { invalidateField } from "../../src";
+
+const ROOT_QUERY = { product: {} };
+const testObj1 = { id: "obj1", name: "foo" };
+const testObj2 = { id: "obj2", names: ["foo", "bar"] };
+const testObj4 = { id: "obj4", "names(id:1)": ["foo", "bar"] };
+type IdArgs = { readonly id: number };
+
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "invalidateField recursive=true with shallow data",
+    patches: [invalidateField<typeof testObj2>("obj2", "names", true)],
+    cacheBefore: { obj2: testObj2 },
+    cacheAfter: { obj2: testObj2 },
+    staleBefore: {},
+    staleAfter: { obj2: new Set(["names"]) }
+  },
+  {
+    name: "invalidateField WithParams recursive=true",
+    // eslint-disable-next-line
+    patches: [invalidateField<any>("obj4", "names", true)],
+    cacheBefore: { obj4: testObj4 },
+    cacheAfter: { obj4: testObj4 },
+    staleBefore: {},
+    staleAfter: { obj4: new Set(["names(id:1)"]) }
+  },
+  {
+    name: "invalidateField recursive=false with deep data",
+    // eslint-disable-next-line
+    patches: [invalidateField<any>("myid", "prop", false)],
+    cacheBefore: {
+      myid: { prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    cacheAfter: {
+      myid: { prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    staleBefore: {},
+    staleAfter: {
+      myid: new Set(["prop"])
+    }
+  },
+  {
+    name: "invalidateField recursive=true with deep data",
+    // eslint-disable-next-line
+    patches: [invalidateField<any>("myid", "prop", true)],
+    cacheBefore: {
+      myid: { prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    cacheAfter: {
+      myid: { prop: "obj:1" },
+      "obj:1": { id: "1", news: ["NewsItemType:1", "NewsItemType:2"] },
+      "NewsItemType:1": { id: 1, header: "olle" },
+      "NewsItemType:2": { id: 2, header: "olle2" }
+    },
+    staleBefore: {},
+    staleAfter: {
+      myid: new Set(["prop"]),
+      "obj:1": new Set(["id", "news"]),
+      "NewsItemType:1": new Set(["id", "header"]),
+      "NewsItemType:2": new Set(["id", "header"])
+    }
+  },
+  {
+    name:
+      "invalidateField recursive=true should do nothing if entity is missing in cache",
+    patches: [invalidateField<typeof testObj2>("notobj2", "names", true)],
+    cacheBefore: { obj2: testObj2 },
+    cacheAfter: { obj2: testObj2 },
+    staleBefore: {},
+    staleAfter: {}
+  },
+  {
+    name:
+      "invalidateField recursive=true should do nothing if field is missing in cache",
+    patches: [invalidateField<typeof testObj2>("obj2", "names", true)],
+    cacheBefore: { obj2: testObj1 },
+    cacheAfter: { obj2: testObj1 },
+    staleBefore: {},
+    staleAfter: {}
+  },
+  {
+    name:
+      "invalidateField with arguments should only invalidate field with arguments",
+    patches: [
+      invalidateField<typeof ROOT_QUERY, IdArgs>(
+        "ROOT_QUERY",
+        "product",
+        false,
+        { id: 2 }
+      )
+    ],
+    cacheBefore: {
+      ROOT_QUERY: {
+        'product({"id":1})': "Product;1",
+        'product({"id":2})': "Product;2"
+      },
+      "Product;1": { id: 1, sortNo: 0 },
+      "Product;2": { id: 2, sortNo: 0 }
+    },
+    cacheAfter: {
+      ROOT_QUERY: {
+        'product({"id":1})': "Product;1",
+        'product({"id":2})': "Product;2"
+      },
+      "Product;1": { id: 1, sortNo: 0 },
+      "Product;2": { id: 2, sortNo: 0 }
+    },
+    staleBefore: {},
+    staleAfter: {
+      ROOT_QUERY: new Set(['product({"id":2})'])
+    }
+  }
+];

--- a/test/clear-stale/remove-all-fields.ts
+++ b/test/clear-stale/remove-all-fields.ts
@@ -3,9 +3,11 @@ import { OneTest } from "../clear-stale-def";
 /**
  * When there is no fields left, the object should be removed from stale
  */
-export const test: OneTest = {
-  name: "remove last field",
-  normMap: { myid: { id: "myid", name: "foo" } },
-  staleBefore: { myid: new Set(["name"]) },
-  staleAfter: {}
-};
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "remove last field",
+    normMap: { myid: { id: "myid", name: "foo" } },
+    staleBefore: { myid: new Set(["name"]) },
+    staleAfter: {}
+  }
+];

--- a/test/clear-stale/remove-one-field.ts
+++ b/test/clear-stale/remove-one-field.ts
@@ -1,8 +1,10 @@
 import { OneTest } from "../clear-stale-def";
 
-export const test: OneTest = {
-  name: "remove one field",
-  normMap: { myid: { id: "myid", name: "foo" } },
-  staleBefore: { myid: new Set(["name", "age"]) },
-  staleAfter: { myid: new Set(["age"]) }
-};
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "remove one field",
+    normMap: { myid: { id: "myid", name: "foo" } },
+    staleBefore: { myid: new Set(["name", "age"]) },
+    staleAfter: { myid: new Set(["age"]) }
+  }
+];

--- a/test/is-stale/with-stale-false.ts
+++ b/test/is-stale/with-stale-false.ts
@@ -1,14 +1,16 @@
 import { OneTest } from "../is-stale-test-def";
 
-export const test: OneTest = {
-  name: "with stale false",
-  staleMap: {
-    "Post;555": new Set(["author", "title", "comments"])
-  },
-  fields: {
-    ROOT_QUERY: ["posts"],
-    "Post;123": ["id", "__typename", "author", "title", "comments"],
-    "Author;1": ["id", "__typename", "name"]
-  },
-  isStale: false
-};
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "with stale false",
+    staleMap: {
+      "Post;555": new Set(["author", "title", "comments"])
+    },
+    fields: {
+      ROOT_QUERY: ["posts"],
+      "Post;123": ["id", "__typename", "author", "title", "comments"],
+      "Author;1": ["id", "__typename", "name"]
+    },
+    isStale: false
+  }
+];

--- a/test/is-stale/with-stale-true.ts
+++ b/test/is-stale/with-stale-true.ts
@@ -1,14 +1,16 @@
 import { OneTest } from "../is-stale-test-def";
 
-export const test: OneTest = {
-  name: "with stale true",
-  staleMap: {
-    "Post;123": new Set(["author", "title", "comments"])
-  },
-  fields: {
-    ROOT_QUERY: ["posts"],
-    "Post;123": ["id", "__typename", "author", "title", "comments"],
-    "Author;1": ["id", "__typename", "name"]
-  },
-  isStale: true
-};
+export const tests: ReadonlyArray<OneTest> = [
+  {
+    name: "with stale true",
+    staleMap: {
+      "Post;123": new Set(["author", "title", "comments"])
+    },
+    fields: {
+      ROOT_QUERY: ["posts"],
+      "Post;123": ["id", "__typename", "author", "title", "comments"],
+      "Author;1": ["id", "__typename", "name"]
+    },
+    isStale: true
+  }
+];

--- a/test/test-data-utils.ts
+++ b/test/test-data-utils.ts
@@ -1,12 +1,14 @@
 import * as fs from "fs";
 
 export function loadTests<T>(path: string): ReadonlyArray<T> {
+  // eslint-disable-next-line no-path-concat
   const testBasePath = __dirname + "/" + path;
   const importedTests = fs
     .readdirSync(testBasePath)
-    // .filter(f => f.match(/\.test\.ts$/i))
+    // eslint-disable-next-line
     .map(f => require(testBasePath + f))
-    .map(importedModule => importedModule.test as T);
+    .map(importedModule => importedModule.tests as T)
+    .flat();
 
   return importedTests;
 }
@@ -23,7 +25,7 @@ export interface UtilsTest {
 export function onlySkip<T extends UtilsTest>(
   tests: ReadonlyArray<T>
 ): ReadonlyArray<T> {
-  const skips = tests.filter(t => !!!t.skip);
+  const skips = tests.filter(t => !t.skip);
   const onlys = skips.filter(t => t.only === true);
   if (onlys.length > 0) {
     return onlys;


### PR DESCRIPTION
Add patches for invlidation/staleness from the `graphql-norm-patch` package. Since staleness is something "extra", ie. not part of base cache handling, the patches for staleness really belong in this package and should be removed from the `graphql-norm-patch` package.