### PR TITLE
Return cleared fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Return both the new stale map and the cleared fields from `clearStale()`.
+- Return both the new stale map and the cleared fields from `clearStale()`. See PR [#3](https://github.com/dividab/graphql-norm-stale/pull/3).
 
 ## [0.5.0](https://github.com/dividab/graphql-norm-stale/compare/v0.4.0...v0.5.0) - 2019-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/graphql-norm-stale/compare/v0.5.0...master)
 
+### Changed
+
+- Return both the new stale map and the cleared fields from `clearStale()`.
+
 ## [0.5.0](https://github.com/dividab/graphql-norm-stale/compare/v0.4.0...v0.5.0) - 2019-10-13
 
 ### Added

--- a/src/stale.ts
+++ b/src/stale.ts
@@ -16,41 +16,53 @@ export function isStale(staleMap: FieldsMap, fields: FieldsMap): boolean {
 }
 
 /**
- * Removes the stale flag for fields that are present in the normalized result
+ * Removes the stale flag for fields that are present in the normalized result.
+ * Returns tupe of new map of stale fields with the cleared fields removed and
+ * map of the cleared fields
  */
-export function clearStale(normMap: NormMap, staleMap: FieldsMap): FieldsMap {
+export function clearStale(
+  normMap: NormMap,
+  staleMap: FieldsMap
+): [FieldsMap, FieldsMap] {
   type MutableFieldsMap = { [key: string]: Set<string> };
   // Make a shallow copy to enable shallow mutation
-  const staleCopy: MutableFieldsMap = { ...(staleMap as MutableFieldsMap) };
+  const newStaleMap: MutableFieldsMap = { ...(staleMap as MutableFieldsMap) };
+  const clearedMap: MutableFieldsMap = {};
 
   // Check all stale fields against the normalized map
-  for (const staleKey of Object.keys(staleCopy)) {
+  for (const staleKey of Object.keys(newStaleMap)) {
     const normObj = normMap[staleKey];
     if (normObj !== undefined) {
-      const staleFields = staleCopy[staleKey];
+      const staleFields = newStaleMap[staleKey];
       let staleFieldKeyCount = staleFields.size;
 
-      // Check all fields of the stale against the corresponding normalized object fields
+      // Check all fields of the stale set against the corresponding normalized object fields
       // If a field exists in the normalized map, then it should not be stale anymore
-      let staleFieldsCopy: Set<string> | undefined = undefined;
-      for (const staleFieldKey of staleFields) {
+      let staleFieldsSetCopy: Set<string> | undefined = undefined;
+      let clearedFields: Set<string> | undefined = undefined;
+      for (const staleField of staleFields) {
         for (const normField of Object.keys(normObj)) {
-          if (normField === staleFieldKey) {
-            if (!staleFieldsCopy) {
-              staleFieldsCopy = new Set(staleFields);
-              staleCopy[staleKey] = staleFieldsCopy;
+          if (normField === staleField) {
+            if (!staleFieldsSetCopy) {
+              staleFieldsSetCopy = new Set(staleFields);
+              newStaleMap[staleKey] = staleFieldsSetCopy;
             }
-            staleFieldsCopy.delete(staleFieldKey);
+            if (!clearedFields) {
+              clearedFields = new Set();
+              clearedMap[staleKey] = clearedFields;
+            }
+            staleFieldsSetCopy.delete(staleField);
             staleFieldKeyCount--;
+            clearedFields.add(staleField);
           }
         }
       }
 
       // If the normalized object has no stale fields then remove it from stale
       if (staleFieldKeyCount === 0) {
-        delete staleCopy[staleKey];
+        delete newStaleMap[staleKey];
       }
     }
   }
-  return staleCopy;
+  return [newStaleMap, clearedMap];
 }

--- a/test/clear-stale-def.ts
+++ b/test/clear-stale-def.ts
@@ -7,4 +7,5 @@ export interface OneTest {
   readonly normMap: NormMap;
   readonly staleBefore: FieldsMap;
   readonly staleAfter: FieldsMap;
+  readonly clearedAfter: FieldsMap;
 }

--- a/test/clear-stale.test.ts
+++ b/test/clear-stale.test.ts
@@ -2,11 +2,13 @@ import { tests } from "./clear-stale-data";
 import { onlySkip } from "./test-data-utils";
 import { clearStale } from "../src/stale";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function deepFreeze(o: any): any {
   Object.freeze(o);
 
   Object.getOwnPropertyNames(o).forEach(function(prop) {
     if (
+      // eslint-disable-next-line
       o.hasOwnProperty(prop) &&
       o[prop] !== null &&
       (typeof o[prop] === "object" || typeof o[prop] === "function") &&
@@ -19,14 +21,17 @@ function deepFreeze(o: any): any {
   return o;
 }
 
-describe("updateStale() with special test data", () => {
+describe("clearStale() with test data", () => {
   onlySkip(tests).forEach(item => {
     test(item.name, done => {
       // Freeze the test so we test that the function does not mutate the inputs on any level
       deepFreeze(item);
-      const actual = clearStale(item.normMap, item.staleBefore);
-      const expected = item.staleAfter;
-      expect(actual).toEqual(expected);
+      const [newStale, clearedFields] = clearStale(
+        item.normMap,
+        item.staleBefore
+      );
+      expect(newStale).toEqual(item.staleAfter);
+      expect(clearedFields).toEqual(item.clearedAfter);
       done();
     });
   });

--- a/test/clear-stale/remove-all-fields.ts
+++ b/test/clear-stale/remove-all-fields.ts
@@ -8,6 +8,7 @@ export const tests: ReadonlyArray<OneTest> = [
     name: "remove last field",
     normMap: { myid: { id: "myid", name: "foo" } },
     staleBefore: { myid: new Set(["name"]) },
-    staleAfter: {}
+    staleAfter: {},
+    clearedAfter: { myid: new Set(["name"]) }
   }
 ];

--- a/test/clear-stale/remove-one-field.ts
+++ b/test/clear-stale/remove-one-field.ts
@@ -5,6 +5,7 @@ export const tests: ReadonlyArray<OneTest> = [
     name: "remove one field",
     normMap: { myid: { id: "myid", name: "foo" } },
     staleBefore: { myid: new Set(["name", "age"]) },
-    staleAfter: { myid: new Set(["age"]) }
+    staleAfter: { myid: new Set(["age"]) },
+    clearedAfter: { myid: new Set(["name"]) }
   }
 ];


### PR DESCRIPTION
Let the `clearFields()` function return a tuple of the new stale map and the a map of the fields that were cleared (removed fro the original stale map).